### PR TITLE
Fix skimage img_as_ubyte usage

### DIFF
--- a/Pipeline/data_aug.ipynb
+++ b/Pipeline/data_aug.ipynb
@@ -84,7 +84,7 @@
     "            estimated_time_left = elapsed_time * (total_files - completed_files - 1) / 60.0\n",
     "            \n",
     "            # Converting to uint8 before saving \n",
-    "            augmented_image = skimage.img_as_ubyte(augmented_image)\n",
+    "            augmented_image = util.img_as_ubyte(augmented_image)\n",
     "            \n",
     "            # Saving the augmented image with a new name using skimage.io module\n",
     "            io.imsave(os.path.join(folder, \"augmented_\" + file), augmented_image)\n",


### PR DESCRIPTION
## Summary
- fix NameError in data augmentation notebook by using util.img_as_ubyte

## Testing
- `pre-commit` *(fails: no pre-commit config)*